### PR TITLE
Add minimal API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# red_star
+# KOMINTERN
+
+This repository contains a skeleton implementation for the KOMINTERN project.
+It is a minimal proof-of-concept for a planning and management platform based on
+AI methods, using Flask and MongoDB.
+
+## Structure
+
+- `app/` – application package with placeholders for strategy planning and task
+  management.
+- `docker-compose.yml` – configuration for running MongoDB via Docker.
+- `requirements.txt` – Python dependencies.
+
+## Running locally
+
+1. Start MongoDB:
+
+   ```bash
+   docker-compose up -d
+   ```
+
+2. Install Python dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Run the application:
+
+   ```bash
+   python -m flask --app app run
+   ```
+
+## API overview
+
+Once the server is running, the following endpoints are available:
+
+- `GET /` – health check returning `{ "status": "ok" }`.
+- `POST /tasks` – create a new task. Payload must include `name` and `deadline`.
+- `GET /tasks` – list all tasks stored in MongoDB.
+- `POST /plan` – generate a simple plan. Optionally pass `horizon` in days.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,14 @@
+from flask import Flask
+from .database import init_db
+
+
+def create_app():
+    app = Flask(__name__)
+    # Load configuration for database and other settings
+    app.config.from_object('app.config')
+    init_db(app)
+
+    from . import main
+    app.register_blueprint(main.bp)
+
+    return app

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,1 @@
+MONGO_URI = 'mongodb://localhost:27017/komintern'

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,15 @@
+from flask import current_app, g
+from pymongo import MongoClient
+
+
+def init_db(app):
+    @app.before_request
+    def before_request():
+        g.mongo_client = MongoClient(app.config.get('MONGO_URI'))
+        g.db = g.mongo_client.get_default_database()
+
+    @app.teardown_request
+    def teardown_request(exception):
+        client = g.pop('mongo_client', None)
+        if client is not None:
+            client.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,38 @@
+from flask import Blueprint, jsonify, request
+from .tasks import create_task, list_tasks
+from .strategy import StrategyPlanner
+
+bp = Blueprint('main', __name__)
+
+planner = StrategyPlanner()
+
+
+@bp.route('/')
+def index():
+    return jsonify({'status': 'ok'})
+
+
+@bp.route('/tasks', methods=['POST'])
+def add_task():
+    """Create a new task."""
+    data = request.get_json(silent=True) or {}
+    name = data.get('name')
+    deadline = data.get('deadline')
+    if not name or not deadline:
+        return jsonify({'error': 'name and deadline required'}), 400
+    task_id = create_task(name, deadline)
+    return jsonify({'id': task_id}), 201
+
+
+@bp.route('/tasks', methods=['GET'])
+def get_tasks():
+    """List all tasks."""
+    return jsonify(list_tasks())
+
+
+@bp.route('/plan', methods=['POST'])
+def generate_plan():
+    """Generate a simple plan for the given horizon."""
+    data = request.get_json(silent=True) or {}
+    horizon = int(data.get('horizon', 7))
+    return jsonify(planner.generate_plan(horizon))

--- a/app/strategy.py
+++ b/app/strategy.py
@@ -1,0 +1,14 @@
+"""Planning and forecasting module (skeleton)."""
+
+import datetime
+
+
+class StrategyPlanner:
+    def generate_plan(self, horizon_days: int) -> dict:
+        """Return a dummy plan for the given horizon."""
+        today = datetime.date.today()
+        return {
+            'start': today.isoformat(),
+            'end': (today + datetime.timedelta(days=horizon_days)).isoformat(),
+            'tasks': []
+        }

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -1,0 +1,15 @@
+"""Task management module (skeleton)."""
+
+from flask import g
+from bson.objectid import ObjectId
+
+
+def create_task(name: str, deadline: str) -> str:
+    col = g.db.tasks
+    result = col.insert_one({'name': name, 'deadline': deadline, 'done': False})
+    return str(result.inserted_id)
+
+
+def list_tasks() -> list:
+    col = g.db.tasks
+    return [{'id': str(t['_id']), 'name': t['name'], 'deadline': t['deadline'], 'done': t['done']} for t in col.find()]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  mongodb:
+    image: mongo:latest
+    container_name: komintern-mongo
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+volumes:
+  mongo-data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+pymongo
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app
+
+def test_health_check():
+    app = create_app()
+    with app.test_client() as client:
+        res = client.get('/')
+        assert res.status_code == 200
+        assert res.get_json() == {'status': 'ok'}


### PR DESCRIPTION
## Summary
- load config in `create_app`
- add endpoints for tasks and plan generation
- describe API usage in README
- add a simple health-check test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687aa409b250832fabdacbc9ff6452b2